### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,10 +8,9 @@ name: Docker
 on:
   push:
     branches: [ "master" ]
-    tags: [ "latest", "v*.*.*" ]
   pull_request:
     branches: [ "master" ]
-    tags: [ "latest", "v*.*.*" ]
+
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -66,6 +65,14 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            latest
             type=schedule
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,12 +6,10 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '27 19 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'latest','v*.*.*' ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,10 +8,10 @@ name: Docker
 on:
   push:
     branches: [ "master" ]
-    # Publish semver tags as releases.
-    tags: [ 'latest','v*.*.*' ]
+    tags: [ "latest", "v*.*.*" ]
   pull_request:
     branches: [ "master" ]
+    tags: [ "latest", "v*.*.*" ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '27 19 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY *.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o /triflector
+
+FROM gcr.io/distroless/base-debian12 AS run
+WORKDIR /
+COPY --from=build /triflector /triflector
+USER nonroot:nonroot
+EXPOSE 3334
+ENTRYPOINT ["/triflector"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,49 @@ For example, providing `AUTH_BACKEND=http://example.com/check-auth?pubkey=` will
 ### Relay claims
 
 A user may send a `kind 28934` claim event to this relay. If the `claim` tag is in the `RELAY_CLAIMS` list, the pubkey which signed the event will be granted access to the relay.
+
+### Docker
+
+Clone the repository and run `docker build -t triflector:local .` to build the image.
+
+Then you can use Docker Compose or Portainer Stacks to run a container:
+
+```
+services:
+
+  triflector:
+    image: triflector:local
+    container_name: triflector
+    restart: unless-stopped
+    networks:
+      - triflectornet
+    ports:
+      - 3334:3334
+    environment:
+      - DATABASE_URL=postgres://triflector:YOUR_PASSWORD_HERE@database:5432/triflector?sslmode=disable
+
+  database:
+    image: postgres
+    container_name: triflector_db
+    restart: unless-stopped
+    networks:
+      - triflectornet
+    volumes:
+      - triflectordata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=triflector
+      - POSTGRES_USER=triflector
+      - POSTGRES_PASSWORD=YOUR_PASSWORD_HERE
+
+networks:
+
+  triflectornet:
+
+volumes:
+
+  triflectordata:
+```
+
+Make sure to change the example postgres password in both DATABASE_URL and POSTGRES_PASSWORD.
+
+You can add the environment variables from [Basic configuration](#basic-configuration) to the `environment:` section under `triflector:` to customize your relay.

--- a/README.md
+++ b/README.md
@@ -39,15 +39,13 @@ A user may send a `kind 28934` claim event to this relay. If the `claim` tag is 
 
 ## Docker
 
-Clone the repository and run `docker build -t triflector:local .` to build the image.
-
-Then you can use Docker Compose or Portainer Stacks to run a container:
+You can use Docker Compose or Portainer Stacks to run a container:
 
 ```
 services:
 
   triflector:
-    image: triflector:local
+    image: ghcr.io/coracle-social/triflector
     container_name: triflector
     restart: unless-stopped
     networks:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For example, providing `AUTH_BACKEND=http://example.com/check-auth?pubkey=` will
 
 A user may send a `kind 28934` claim event to this relay. If the `claim` tag is in the `RELAY_CLAIMS` list, the pubkey which signed the event will be granted access to the relay.
 
-### Docker
+## Docker
 
 Clone the repository and run `docker build -t triflector:local .` to build the image.
 


### PR DESCRIPTION
I want to make it easier to run ~discord servers on nostr~ relays for flotilla.

This PR sets up github actions to build a docker image containing triflector. I added an example of the contents of a compose.yaml file to run the container including a postgres database.

I put this together real quick as I made it work for a relay of my own, so let me know if I need to add or explain more.